### PR TITLE
Use alpine version 3.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,9 @@
-FROM alpine:3.8
+FROM alpine:3.9
 
 LABEL maintainer="The CoBloX developers team@coblox.tech"
 
 ENV VERSION=0.17.0
 
-RUN sed -i -e 's/v3.8/edge/g' /etc/apk/repositories
 RUN apk add --no-cache bitcoin~$VERSION bitcoin-cli~$VERSION
 
 EXPOSE 8332 8333 18332 18333 18443 18444


### PR DESCRIPTION
This allows us to remove the hack of replacing the repository version we use for fetching the packages.